### PR TITLE
Refactor form components

### DIFF
--- a/src/forms/components.tsx
+++ b/src/forms/components.tsx
@@ -77,7 +77,6 @@ export function createFieldComponent<TV extends FieldValues>(
 /* 1.1  Small helper hook – grabs the RHF control from context if not supplied */
 /* -------------------------------------------------------------------------- */
 function useRHFControl<T extends FieldValues>() {
-  const { useFormContext } = require("react-hook-form") as typeof import("react-hook-form");
   const ctx = useFormContext<T>();
   if (!ctx) {
     throw new Error(

--- a/src/forms/components.tsx
+++ b/src/forms/components.tsx
@@ -1,119 +1,128 @@
-import React from "react";
-import ReactDOM from "react-dom";
+"use client";
 
-import { useForm, UseFormReturn, FieldValues } from "react-hook-form";
+import * as React from "react";
+import ReactDOM from "react-dom";
+import {
+  FieldPath,
+  FieldValues,
+  ControllerRenderProps,
+  useController,
+  UseControllerProps,
+  UseFormReturn,
+  useForm,
+} from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ZodSchema } from "zod";
+import clsx from "clsx";
 
-import { mergeClasses } from "../utils";
+/* -------------------------------------------------------------------------- */
+/* 1. COMPONENT FACTORY                                                       */
+/* -------------------------------------------------------------------------- */
 
-type FormComponentType = React.ForwardRefExoticComponent<
-  React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
->;
+type OptionalComponent = React.ComponentType<{ className?: string }>;
 
-interface withFormComponentsProps {
-  FormField: any; // TODO: Fix this type
-  FormItem: FormComponentType;
-  FormLabel: any; // TODO: Fix this type
-  FormControl: any; // TODO: Fix this type
-  FormDescription?: FormComponentType;
-  FormMessage?: FormComponentType;
-}
-
-interface CustomFormFieldProps {
-  name: string;
-  label?: React.ReactNode | string;
-  description?: React.ReactNode | string;
-  className?: string | string[];
-  render: (field: any) => React.ReactElement;
+export interface ComponentSet {
+  Item: OptionalComponent;
+  Label: OptionalComponent;
+  Control: OptionalComponent;
+  Message: OptionalComponent;
+  Description: OptionalComponent;
 }
 
 /**
- * This function is a higher order component that takes a configuration object
- * with the form components to be used (FormField, FormItem, FormLabel, FormControl,
- * FormDescription, FormMessage)
- * and returns a function that can be used to create custom form fields.
+ * Returns a strongly typed `<Field>` component bound to the provided
+ * rhf `useForm` context. Accepts a custom component set so you can
+ * theme or replace them project-wide from a single place.
  */
-export function withFormComponents({
-  FormField,
-  FormItem,
-  FormLabel,
-  FormControl,
-  FormDescription,
-  FormMessage,
-}: withFormComponentsProps): React.FC<CustomFormFieldProps> {
-  // (props: CustomFormFieldProps) => JSX.Element {
-  return function CustomFormField({
-    name,
-    label = "",
-    description = "",
-    className = "",
-    render,
-  }: CustomFormFieldProps) {
-    return (
-      <FormField
-        key={name}
-        name={name}
-        render={({ field }: any) => {
-          if (
-            field &&
-            typeof field === "object" &&
-            "value" in field &&
-            field.value === null
-          )
-            field.value = ""; // Set to an empty string to avoid warnings
+export function createFieldComponent<TV extends FieldValues>(
+  components: ComponentSet,
+) {
+  const { Item, Label, Control, Message, Description } = components;
 
-          return (
-            <FormItem className={mergeClasses("form-item", className)}>
-              {label && <FormLabel>{label}</FormLabel>}
-              <FormControl>
-                {/*React.cloneElement(input as React.ReactElement<any>, { ...field })*/}
-                {render(field)}
-              </FormControl>
-              {description && FormDescription && (
-                <FormDescription className="form-item-description">
-                  {description}
-                </FormDescription>
-              )}
-              {FormMessage && <FormMessage className="form-item-message" />}
-            </FormItem>
-          );
-        }}
-      />
+  return function Field<P extends FieldPath<TV>>({
+    name,
+    label,
+    description,
+    className,
+    control,
+    render,
+    ...controllerProps
+  }: {
+    name: P;
+    control?: UseFormReturn<TV>["control"];
+    label?: React.ReactNode;
+    description?: React.ReactNode;
+    className?: string;
+    render: (field: ControllerRenderProps<TV, P>) => React.ReactElement;
+  } & Omit<UseControllerProps<TV, P>, "name" | "control">) {
+    const ctxControl = useRHFControl<TV>();
+    const { field, fieldState } = useController<TV, P>({
+      name,
+      control: control || ctxControl,
+      ...controllerProps,
+    });
+
+    return (
+      <Item className={clsx("form-item", className)}>
+        {label && <Label>{label}</Label>}
+        <Control>{render(field)}</Control>
+        {description && <Description>{description}</Description>}
+        {fieldState.error?.message && <Message>{fieldState.error.message}</Message>}
+      </Item>
     );
   };
 }
 
-export interface iActionState {
-  status: string; // TODO: Define a type for this, such as "idle" | "loading" | "success" | "error"
-  data?: FieldValues;
+/* -------------------------------------------------------------------------- */
+/* 1.1  Small helper hook – grabs the RHF control from context if not supplied */
+/* -------------------------------------------------------------------------- */
+function useRHFControl<T extends FieldValues>() {
+  const { useFormContext } = require("react-hook-form") as typeof import("react-hook-form");
+  const ctx = useFormContext<T>();
+  if (!ctx) {
+    throw new Error(
+      "<Field> requires either a `control` prop or to be rendered inside a <FormProvider>.",
+    );
+  }
+  return ctx.control;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2. RHF + Async Action helper                                               */
+/* -------------------------------------------------------------------------- */
+
+type ActionStatus = "idle" | "loading" | "success" | "error";
+
+export interface ActionState<T extends FieldValues = FieldValues> {
+  status: ActionStatus;
+  data?: T;
   message?: string;
 }
 
-export interface iAction {
-  (prevState: any, formData: FieldValues): Promise<iActionState>;
+export interface ServerAction<T extends FieldValues, R extends ActionState<T>> {
+  (prevState: R, formData: T): Promise<R>;
 }
 
-export function useFormWithAction<FF extends FieldValues>(
-  schema: ZodSchema<FF>,
-  defaultValues: any,
-  action: iAction,
-  initialState?: iActionState,
-): {
-  form: UseFormReturn<FF>;
-  state: FF;
-  serverAction: (data: FF) => void;
-} {
-  const form = useForm<FF>({
+export function useFormWithAction<
+  T extends FieldValues,
+  R extends ActionState<T> = ActionState<T>,
+>(
+  schema: ZodSchema<T>,
+  defaultValues: T,
+  action: ServerAction<T, R>,
+  initialState: R = { status: "idle" } as R,
+) {
+  const form = useForm<T>({
     resolver: zodResolver(schema),
     defaultValues,
   });
 
-  // @ts-ignore
-  const [state, serverAction] = ReactDOM.useFormState(
+  // @ts-expect-error experimental React / next-server-actions typing
+  const [state, serverAction] = ReactDOM.useFormState<R, T>(
     action,
-    initialState || { status: "idle" },
+    initialState,
   );
 
-  return { form, state, serverAction };
+  return { form, state, serverAction } as const;
 }
+

--- a/src/forms/components.tsx
+++ b/src/forms/components.tsx
@@ -10,6 +10,7 @@ import {
   UseControllerProps,
   UseFormReturn,
   useForm,
+  useFormContext
 } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ZodSchema } from "zod";


### PR DESCRIPTION
## Summary
- implement `createFieldComponent` with typed API
- support injection of form UI components
- update form action utilities

## Testing
- `npm run build` *(fails: rollup not found)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841a8b525e48321ae8f57dd65929d85